### PR TITLE
Bump nw-builder to latest 3.8.5 supported version.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,7 @@ const nwVersion = '0.76.0',
     availablePlatforms = ['linux32', 'linux64', 'win32', 'osx64'],
     releasesDir = 'build';
 
+
 /*************** 
  * dependencies *
  ***************/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,6 @@ const nwVersion = '0.76.0',
     availablePlatforms = ['linux32', 'linux64', 'win32', 'osx64'],
     releasesDir = 'build';
 
-
 /*************** 
  * dependencies *
  ***************/
@@ -17,7 +16,6 @@ const gulp = require('gulp'),
     runSequence = require('run-sequence'),
     nwBuilder = require('nw-builder'),
     del = require('del'),
-    currentPlatform = require('nw-builder/lib/detectCurrentPlatform.js'),
     yargs = require('yargs'),
     fs = require('fs'),
     path = require('path'),
@@ -26,6 +24,8 @@ const gulp = require('gulp'),
     pkJson = require('./package.json'),
     modClean = require('modclean').ModClean;
 
+const { detectCurrentPlatform } = require("nw-builder/dist/index.cjs");
+const currentPlatform = () => { return detectCurrentPlatform(process) };
 
 /***********
  *  custom  *

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "jshint": "^2.12.0",
         "jshint-stylish": "^2.2.1",
         "modclean": "^3.0.0-beta.1",
-        "nw-builder": "3.5.7",
+        "nw-builder": "3.8.5",
         "run-sequence": "^2.2.1",
         "yargs": "^16.2.0"
     }


### PR DESCRIPTION
Hello!

I'm trying to get the project to build in a version of NW.js that supports "Mac OS X (arm64)" such as https://nwjs.io/blog/v0.94.0/

For that to happen I believe I need to upgrade nw-builder as well, so this PR is a step into first fixing a change related to to `detectCurrentPlatform` being moved.

Location of `detectCurrentPlatform` moved, see:
https://github.com/nwutils/nw-builder/pull/564/files

Tested build with
```sh
gulp build  --platforms osx64
```