### PR TITLE
WIP: Use nw-builder v4.0.7

### DIFF
--- a/app/js/vendor/platform.js
+++ b/app/js/vendor/platform.js
@@ -1,0 +1,20 @@
+/**
+ * Get user's computer platform
+ *
+ * @param  {string}                            platform  Node's process.platform
+ * @return {"osx"| "win" | "linux" | "string"}           Platform types
+ */
+const getPlatform = (platform) => {
+  switch (platform) {
+    case "darwin":
+      return "osx";
+    case "win32":
+      return "win";
+    case "linux":
+      return "linux";
+    default:
+      return platform;
+  }
+};
+
+module.exports = { getPlatform };

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "jshint": "^2.12.0",
         "jshint-stylish": "^2.2.1",
         "modclean": "^3.0.0-beta.1",
-        "nw-builder": "3.8.5",
+        "nw-builder": "^4.0.7",
         "run-sequence": "^2.2.1",
         "yargs": "^16.2.0"
     }


### PR DESCRIPTION
I'm no Javascript expert but would you be interested in a PR that tries to upgrade nw-builder to the latest version `4.13.7` and possibly NW.js to `v0.94.0`?

Tried to follow the migration path for nw-builder described here:

https://github.com/nwutils/nw-builder/tree/v4.0.3?tab=readme-ov-file#migration-to-v4


Couple of questions:

1. Since the latest versions of nw-builder require `platform` property, would you consider removing the dependency on nw-builder get platform name from the gulp task? Or am I seeing things wrong?

https://github.com/nwutils/nw-builder?tab=readme-ov-file#api-reference

nw-builder first moved the file again to `src/util/platform.js` 
https://github.com/nwutils/nw-builder/compare/v3.8.10...v4.0.7#diff-4dbd0a6d4d2f9999a53e0fe28c45f303bac69dbfb3aba774962443725234cf9d

I've tried to import it with
```js
const { getPlatform } = require("nw-builder/src/util/platform");
const currentPlatform = () => { return getPlatform(process.platform) };
```

But I'm getting an error that I don't know if it's possible to solve, since the function is not exported.
```
$ gulp build  --platforms osx64
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './src/util/platform' is not defined by "exports" in /Users/andre/code/opensubtitles-uploader/node_modules/nw-builder/package.json
    at new NodeError (node:internal/errors:405:5)
    at exportsNotFound (node:internal/modules/esm/resolve:366:10)
    at packageExportsResolve (node:internal/modules/esm/resolve:713:9)
    at resolveExports (node:internal/modules/cjs/loader:584:36)
    at Module._findPath (node:internal/modules/cjs/loader:658:31)
    at Module._resolveFilename (node:internal/modules/cjs/loader:1120:27)
    at Module._load (node:internal/modules/cjs/loader:975:27)
    at Module.require (node:internal/modules/cjs/loader:1225:19)
    at require (node:internal/modules/helpers:177:18)
    at Object.<anonymous> (/Users/andre/code/opensubtitles-uploader/gulpfile.js:31:25) {
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
}
```
Could copy the file to the vendor folder and move on, which I did in order to progress the build.

nw-builder moved platform.js again in
https://github.com/nwutils/nw-builder/pull/910/files#diff-ded7d82adc6eea35c2e80c2cf91ea002bd00db3073decc2812add012d5872efcR33


2. I'm not sure about the described usage of CJS modules with nwbuild, opened a question on nw-builder side:

https://github.com/nwutils/nw-builder/issues/1331


My end goal is to build opensubtitles-uploader with https://dl.nwjs.io/v0.94.0/nwjs-v0.94.0-osx-arm64.zip